### PR TITLE
fix reftab.js typo

### DIFF
--- a/lib/reftab.js
+++ b/lib/reftab.js
@@ -12,7 +12,7 @@ function Reftab(options) {
 
   const url = 'https://www.reftab.com/api/';
   const publicKey = options.publicKey;
-  const secretKey = options.publicKey;
+  const secretKey = options.secretKey;
 
   const signRequest = function(request) {
     const body = request.body;


### PR DESCRIPTION
Change `const secretKey = options.publicKey;` to `const secretKey = options.secretKey;`